### PR TITLE
Add support for scoped deadlines and timeouts

### DIFF
--- a/duet/__init__.py
+++ b/duet/__init__.py
@@ -277,7 +277,7 @@ def pstarmap_aiter(
 async def sleep(time: float) -> None:
     """Sleeps for the given length of time in seconds."""
     try:
-        async with timeout(time):
+        async with timeout_scope(time):
             await AwaitableFuture()
     except TimeoutError:
         pass
@@ -295,7 +295,7 @@ async def deadline_scope(deadline: float) -> AsyncIterator[None]:
 
 
 @asynccontextmanager
-async def timeout(timeout: float) -> AsyncIterator[None]:
+async def timeout_scope(timeout: float) -> AsyncIterator[None]:
     """Enter a scope that will exit when the timeout elapses.
 
     Args:

--- a/duet/__init__.py
+++ b/duet/__init__.py
@@ -275,7 +275,7 @@ def pstarmap_aiter(
 
 
 async def sleep(time: float) -> None:
-    """Sleeps for the given length of time"""
+    """Sleeps for the given length of time in seconds."""
     try:
         async with timeout(time):
             await AwaitableFuture()
@@ -284,13 +284,23 @@ async def sleep(time: float) -> None:
 
 
 @asynccontextmanager
-async def deadline(deadline: float) -> AsyncIterator[None]:
+async def deadline_scope(deadline: float) -> AsyncIterator[None]:
+    """Enter a scope that will exit when the deadline elapses.
+
+    Args:
+        deadline: Absolute time in epoch seconds when the scope should exit.
+    """
     async with new_scope(deadline=deadline):
         yield
 
 
 @asynccontextmanager
 async def timeout(timeout: float) -> AsyncIterator[None]:
+    """Enter a scope that will exit when the timeout elapses.
+
+    Args:
+        timeout: Time in seconds from now when the scope should exit.
+    """
     async with new_scope(timeout=timeout):
         yield
 
@@ -311,6 +321,12 @@ async def new_scope(
     If an error is raised by the code in the block itself or by any of the
     spawned tasks, all other background tasks will be interrupted and the block
     will raise an error.
+
+    Args:
+        deadline: Absolute time in epoch seconds when the scope should exit.
+        timeout: Time in seconds from now when the scope should exit. If both
+            deadline and timeout are given, the actual deadline will be
+            whichever one will elapse first.
     """
     main_task = impl.current_task()
     scheduler = main_task.scheduler

--- a/duet/duet_test.py
+++ b/duet/duet_test.py
@@ -414,7 +414,7 @@ class TestScope:
     async def test_timeout(self):
         start = time.time()
         with pytest.raises(TimeoutError):
-            async with duet.timeout(0.5):
+            async with duet.timeout_scope(0.5):
                 await duet.AwaitableFuture()
         assert abs((time.time() - start) - 0.5) < 0.2
 
@@ -422,7 +422,7 @@ class TestScope:
     async def test_deadline(self):
         start = time.time()
         with pytest.raises(TimeoutError):
-            async with duet.deadline(time.time() + 0.5):
+            async with duet.deadline_scope(time.time() + 0.5):
                 await duet.AwaitableFuture()
         assert abs((time.time() - start) - 0.5) < 0.2
 

--- a/duet/duet_test.py
+++ b/duet/duet_test.py
@@ -340,8 +340,8 @@ class TestLimiter:
 @duet.sync
 async def test_sleep():
     start = time.time()
-    await duet.sleep(0.2)
-    assert abs((time.time() - start) - 0.2) < 0.02
+    await duet.sleep(0.5)
+    assert abs((time.time() - start) - 0.5) < 0.2
 
 
 class TestScope:
@@ -414,17 +414,17 @@ class TestScope:
     async def test_timeout(self):
         start = time.time()
         with pytest.raises(TimeoutError):
-            async with duet.timeout(0.2):
+            async with duet.timeout(0.5):
                 await duet.AwaitableFuture()
-        assert abs((time.time() - start) - 0.2) < 0.02
+        assert abs((time.time() - start) - 0.5) < 0.2
 
     @duet.sync
     async def test_deadline(self):
         start = time.time()
         with pytest.raises(TimeoutError):
-            async with duet.deadline(time.time() + 0.2):
+            async with duet.deadline(time.time() + 0.5):
                 await duet.AwaitableFuture()
-        assert abs((time.time() - start) - 0.2) < 0.02
+        assert abs((time.time() - start) - 0.5) < 0.2
 
     @duet.sync
     async def test_scope_timeout_cancels_all_subtasks(self):
@@ -440,11 +440,11 @@ class TestScope:
 
         start = time.time()
         with pytest.raises(TimeoutError):
-            async with duet.new_scope(timeout=0.2) as scope:
+            async with duet.new_scope(timeout=0.5) as scope:
                 scope.spawn(task)
                 scope.spawn(task)
                 await duet.AwaitableFuture()
-        assert abs((time.time() - start) - 0.2) < 0.02
+        assert abs((time.time() - start) - 0.5) < 0.2
         assert task_timeouts == [True, True]
 
 

--- a/duet/impl.py
+++ b/duet/impl.py
@@ -267,6 +267,19 @@ class ReadySet:
 
 @functools.total_ordering
 class DeadlineEntry:
+    """A entry for one Deadline in the Scheduler's priority queue.
+
+    This follows the implementation notes in the stdlib heapq docs:
+    https://docs.python.org/3/library/heapq.html#priority-queue-implementation-notes
+
+    In particular:
+    - Includes a monotonically increasing count on each DeadlineEntry instance to
+        preserve creation order when comparing entries with the same deadline.
+    - Includes a valid flag which is set when the associated Task exits the scope
+        before this deadline elapses. The DeadlineEntry is then marked invalid but
+        left in the priority queue; the Scheduler ignores invalid entries when
+        they elapse.
+    """
 
     _counter = itertools.count()
 

--- a/duet/impl.py
+++ b/duet/impl.py
@@ -272,13 +272,16 @@ class DeadlineEntry:
     This follows the implementation notes in the stdlib heapq docs:
     https://docs.python.org/3/library/heapq.html#priority-queue-implementation-notes
 
-    In particular:
-    - Includes a monotonically increasing count on each DeadlineEntry instance to
-        preserve creation order when comparing entries with the same deadline.
-    - Includes a valid flag which is set when the associated Task exits the scope
-        before this deadline elapses. The DeadlineEntry is then marked invalid but
-        left in the priority queue; the Scheduler ignores invalid entries when
-        they elapse.
+    Attributes:
+        task: The task associated with this deadline.
+        deadline: Absolute time when the deadline will elapse.
+        count: Monotonically-increasing counter to preserve creation order when
+            comparing entries with the same deadline.
+        valid: Flag indicating whether the deadline is still valid. If the task
+            exits its scope before the deadline elapses, we mark the deadline as
+            invalid but leave it in the scheduler's priority queue since removal
+            would require an O(n) scan. The scheduler ignores invalid deadlines
+            when they elapse.
     """
 
     _counter = itertools.count()


### PR DESCRIPTION
Fixes #28 

This adds support for timeouts/deadlines in duet scopes. Within a scope with a deadline, any await on a future that does not complete by the deadline will raise a `TimeoutError`. Deadlines in a scope are also inherited by tasks spawned within that scope. In addition, nested scopes can have their own deadlines though the effective deadline will always be the min of the scope's own deadline and the parent scope's deadline.

For now, I've done a simple implementation of a priority queue for keeping track of timeouts, following the implementation notes in the python [heapq module](https://docs.python.org/3/library/heapq.html#priority-queue-implementation-notes). We could also try doing something like a [hashed wheel timer](https://blog.acolyer.org/2015/11/23/hashed-and-hierarchical-timing-wheels/) though we should probably benchmark different implementations.