### PR TITLE
Add support for cancelling scopes

### DIFF
--- a/duet/__init__.py
+++ b/duet/__init__.py
@@ -32,6 +32,8 @@ which makes it possible to implement things like the pmap function below which
 wraps async code into a generator interface.
 """
 
+from concurrent.futures import CancelledError
+
 from duet._version import __version__
 from duet.aitertools import aenumerate, aiter, AnyIterable, AsyncCollector, azip
 from duet.api import (

--- a/duet/api.py
+++ b/duet/api.py
@@ -17,6 +17,7 @@ import collections
 import contextlib
 import functools
 import inspect
+from concurrent.futures import CancelledError
 from typing import (
     Any,
     AsyncIterator,
@@ -356,6 +357,9 @@ class Scope:
         self._main_task = main_task
         self._scheduler = scheduler
         self._tasks = tasks
+
+    def cancel(self) -> None:
+        self._main_task.interrupt(self._main_task, CancelledError())
 
     def spawn(self, func: Callable[..., Awaitable[Any]], *args, **kwds) -> None:
         """Starts a background task that will run the given function."""

--- a/duet/impl.py
+++ b/duet/impl.py
@@ -171,6 +171,8 @@ class Task(Generic[T]):
             return
         self._interrupt = Interrupt(task, error)
         self._ready_future.try_set_result(None)
+        if self._future:
+            self._future.cancel()
 
     def close(self):
         self._generator.close()


### PR DESCRIPTION
This support is pretty basic, but seems to work. I think we'll probably make a preview release so we can iterate on the API a bit before stabilizing in a real release.