### PR TITLE
Fix duet.sync typing plugin

### DIFF
--- a/duet/typing.py
+++ b/duet/typing.py
@@ -56,7 +56,7 @@ def duet_sync_callback(ctx: FunctionContext) -> Type:
 
 class DuetPlugin(Plugin):
     def get_function_hook(self, fullname: str) -> Optional[Callable[[FunctionContext], Type]]:
-        if fullname == "duet.sync":
+        if fullname == "duet.api.sync":
             return duet_sync_callback
         return None
 


### PR DESCRIPTION
This was broken by the rafactoring in #32, which changed the full name of the `sync` function. We expose it as `duet.sync` but the full name is `duet.api.sync`.