### PR TITLE
Add requirements to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include LICENSE
+include requirements.txt
+include dev/requirements.txt


### PR DESCRIPTION
`setup.py` reads the _requirements.txt_ file in this line: https://github.com/google/duet/blob/b7ea9facace0a7ef317c87980eb42238dba3a01f/setup.py#L50-L51

These files are not available in the source distribution on PyPI which means that installing from source from PyPI is not possible.

PyPI: https://pypi.org/project/duet/#files