### PR TITLE
Drop python 3.6 from test matrix for windows and macOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     name: Pytest Windows
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,6 +1,6 @@
-black == 20.8b1
+black == 22.1.*
 isort == 5.7.*
-mypy == 0.782.*
+mypy == 0.931.*
 pylint == 2.10.*
 pytest == 6.2.*
 twine == 3.3.*


### PR DESCRIPTION
Python 3.6 is not longer available with the setup-python action for windows and macOS (see test failures at https://github.com/google/duet/runs/5440091076?check_suite_focus=true).