### PR TITLE
Ensure that `duet.sleep` raises an exception due to outer timeout

### DIFF
--- a/duet/api_test.py
+++ b/duet/api_test.py
@@ -346,10 +346,29 @@ async def test_sleep():
 
 
 @duet.sync
+async def test_sleep_with_timeout():
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        async with duet.timeout_scope(0.5):
+            await duet.sleep(10)
+    assert abs((time.time() - start) - 0.5) < 0.2
+
+
+@duet.sync
 async def test_repeated_sleep():
     start = time.time()
     for _ in range(5):
         await duet.sleep(0.1)
+    assert abs((time.time() - start) - 0.5) < 0.2
+
+
+@duet.sync
+async def test_repeated_sleep_with_timeout():
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        async with duet.timeout_scope(0.5):
+            for _ in range(5):
+                await duet.sleep(0.2)
     assert abs((time.time() - start) - 0.5) < 0.2
 
 


### PR DESCRIPTION
`duet.sleep` works by creating a timeout scope and then swallowing the resulting `TimeoutError`. However, if we have a sleep inside an outer scope that is set to timeout earlier, we want the `duet.sleep` call to actually raise an error because it times out before sleeping for the expected length of time. To make this work, we attach a `TimeoutError` instance to each scope and keep track of it internally on the deadline entries. If `duet.sleep` gets a `TimeoutError` from a different scope, it will reraise it instead of swallowing it.