### PR TITLE
Add support for wrapping abstract methods with duet.sync

### DIFF
--- a/duet/api_test.py
+++ b/duet/api_test.py
@@ -571,9 +571,7 @@ class TestSync:
             async def foo_async(self, a: int) -> int:
                 return a * 3
 
-        with pytest.raises(
-            TypeError, match="Can't instantiate abstract class Foo.*foo_async"
-        ):
+        with pytest.raises(TypeError, match="Can't instantiate abstract class Foo.*foo_async"):
             _ = Foo()
         assert Bar().foo(5) == 15
 

--- a/duet/api_test.py
+++ b/duet/api_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
 import concurrent.futures
 import inspect
 import sys
@@ -541,3 +542,47 @@ async def test_multiple_calls_to_future_set_result():
 
         scope.spawn(set_results, f0, f1)
         await f1
+
+
+class TestSync:
+    def test_sync_on_overridden_method(self):
+        class Foo:
+            async def foo_async(self, a: int) -> int:
+                return a * 2
+
+            foo = duet.sync(foo_async)
+
+        class Bar(Foo):
+            async def foo_async(self, a: int) -> int:
+                return a * 3
+
+        assert Foo().foo(5) == 10
+        assert Bar().foo(5) == 15
+
+    def test_sync_on_abstract_method(self):
+        class Foo(abc.ABC):
+            @abc.abstractmethod
+            async def foo_async(self, a: int) -> int:
+                pass
+
+            foo = duet.sync(foo_async)
+
+        class Bar(Foo):
+            async def foo_async(self, a: int) -> int:
+                return a * 3
+
+        with pytest.raises(
+            TypeError, match="Can't instantiate abstract class Foo with abstract methods foo_async"
+        ):
+            _ = Foo()
+        assert Bar().foo(5) == 15
+
+    def test_sync_on_classmethod(self):
+        with pytest.raises(TypeError, match="duet.sync cannot be applied to classmethod"):
+
+            class _Foo:
+                @classmethod
+                async def foo_async(cls, a: int) -> int:
+                    return a * 2
+
+                foo = duet.sync(foo_async)

--- a/duet/api_test.py
+++ b/duet/api_test.py
@@ -572,7 +572,7 @@ class TestSync:
                 return a * 3
 
         with pytest.raises(
-            TypeError, match="Can't instantiate abstract class Foo with abstract methods foo_async"
+            TypeError, match="Can't instantiate abstract class Foo.*foo_async"
         ):
             _ = Foo()
         assert Bar().foo(5) == 15


### PR DESCRIPTION
If a superclass has an abstract async method that is wrapped with `duet.sync`, we want to be able to instantiate subclasses just by implementing the async method and not also the sync wrapper.

Also added an explicit check for `classmethod` in the implementation of `duet.sync` because it turns out that doesn't work as intended. We could add support for classmethods in the future.