### PR TITLE
Fix timeout clipping in `Scheduler.tick`

### DIFF
--- a/duet/impl.py
+++ b/duet/impl.py
@@ -392,7 +392,7 @@ class Scheduler:
                     break
                 try:
                     ready_tasks = self._ready_tasks.get_all(
-                        min(0, max(timeout, threading.TIMEOUT_MAX))
+                        max(0, min(timeout, threading.TIMEOUT_MAX))
                     )
                     break
                 except TimeoutError:


### PR DESCRIPTION
The previously logic was wrong and would force non-zero timeouts to 0, causing `tick` to go into a tight loop repeatedly calling `get_all` until a task became ready. This didn't affect the correctness of operation of the scheduler, but it caused high CPU usage which impacted performance.