### PR TITLE
Simplify `duet.run` and remove `Scheduler` contextmanager methods

### DIFF
--- a/duet/impl.py
+++ b/duet/impl.py
@@ -441,13 +441,13 @@ class Scheduler:
             frame = frame.f_back
         return False
 
-    def init_signals(self) -> None:
+    def init_signals(self):
         if (
             threading.current_thread() == threading.main_thread()
             and signal.getsignal(signal.SIGINT) == signal.default_int_handler
         ):
             self._prev_signal = signal.signal(signal.SIGINT, self._interrupt)
 
-    def cleanup_signals(self) -> None:
+    def cleanup_signals(self):
         if self._prev_signal:
             signal.signal(signal.SIGINT, self._prev_signal)

--- a/duet/impl.py
+++ b/duet/impl.py
@@ -443,8 +443,8 @@ class Scheduler:
 
     def init_signals(self) -> None:
         if (
-                threading.current_thread() == threading.main_thread()
-                and signal.getsignal(signal.SIGINT) == signal.default_int_handler
+            threading.current_thread() == threading.main_thread()
+            and signal.getsignal(signal.SIGINT) == signal.default_int_handler
         ):
             self._prev_signal = signal.signal(signal.SIGINT, self._interrupt)
 


### PR DESCRIPTION
This inlines the logic from `Scheduler.__enter__` and `Scheduler.__exit__` in `duet.run`, which makes the implementation significantly simpler because there is only one exception path instead of two (previously, had to handle exceptions passed into `__exit__` as well as exceptions that happened inside `__exit__`). This also eliminates two stack frames from tracebacks involving `duet.run`, which can be hard to understand.