### PR TITLE
AwaitableFuture: check cancelled future in callback

### DIFF
--- a/duet/futuretools.py
+++ b/duet/futuretools.py
@@ -45,6 +45,9 @@ class FutureLike(Protocol[T]):
     def cancel(self) -> bool:
         ...
 
+    def cancelled(self) -> bool:
+        ...
+
 
 class AwaitableFuture(Future, Generic[T]):
     """A Future that can be awaited."""
@@ -67,6 +70,9 @@ class AwaitableFuture(Future, Generic[T]):
                 future.cancel()
 
         def callback(future: FutureLike[T]):
+            if future.cancelled():
+                return
+
             error = future.exception()
             if error is None:
                 awaitable.try_set_result(future.result())

--- a/duet/futuretools.py
+++ b/duet/futuretools.py
@@ -71,13 +71,13 @@ class AwaitableFuture(Future, Generic[T]):
 
         def callback(future: FutureLike[T]):
             if future.cancelled():
-                return
-
-            error = future.exception()
-            if error is None:
-                awaitable.try_set_result(future.result())
+                awaitable.cancel()
             else:
-                awaitable.try_set_exception(error)
+                error = future.exception()
+                if error is None:
+                    awaitable.try_set_result(future.result())
+                else:
+                    awaitable.try_set_exception(error)
 
         awaitable.add_done_callback(cancel)
         future.add_done_callback(callback)


### PR DESCRIPTION
Otherwise this exception is logged:

```
ERROR    concurrent.futures:_base.py:342 exception calling callback for <Future at 0x7fca4a9cccd0 state=cancelled>
Traceback (most recent call last):
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 340, in _invoke_callbacks
    callback(self)                                                                                                                  File "/usr/local/google/home/cxing/proj/duet/duet/futuretools.py", line 70, in callback
    error = future.exception()
            ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/concurrent/futures/_base.py", line 483, in exception
    raise CancelledError()
concurrent.futures._base.CancelledError
```