### PR TITLE
Drop support for python < 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.7'
+          python-version: '3.9'
           architecture: 'x64'
       - name: Install black
         run: pip install -r dev/requirements.txt
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.7'
+          python-version: '3.9'
           architecture: 'x64'
       - name: Install mypy
         run: pip install -r dev/requirements.txt
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.7'
+          python-version: '3.9'
           architecture: 'x64'
       - name: Install pylint
         run: pip install -r dev/requirements.txt
@@ -50,7 +50,7 @@ jobs:
     name: Import check
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
     name: Pytest Linux
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
     name: Pytest Windows
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     url="http://github.com/google/duet",
     author="The Duet Authors",
     author_email="maffoo@google.com",
-    python_requires=">=3.7.0",
+    python_requires=">=3.9.0",
     install_requires=requirements,
     extras_require={
         "dev_env": dev_requirements,


### PR DESCRIPTION
This follows the supported versions for cirq: https://github.com/quantumlib/Cirq/pull/6167